### PR TITLE
Add directory input option

### DIFF
--- a/htmlPy/binder.js
+++ b/htmlPy/binder.js
@@ -66,7 +66,7 @@ var bind_all = function () {
         if(!forms[fi].classList.contains("htmlpy-activated")){
             forms[fi].onsubmit = form_bind;
             form = forms[fi];
-            for (i = 0, ii = form.length; i < ii; ++i) {
+            for (var i = form.length - 1; i >= 0; i--) {
                 var input = form[i];
                 if (input.type === "file") {
                     var fileboxname = input.getAttribute("name");
@@ -86,7 +86,6 @@ var bind_all = function () {
                     input.parentNode.insertBefore(button, disabledInput.nextSibling);
 
                     input.style.display = "none";
-                    form[i].remove();
                 }
             }
             forms[fi].classList.add("htmlpy-activated");

--- a/htmlPy/binder.js
+++ b/htmlPy/binder.js
@@ -83,7 +83,7 @@ var bind_all = function () {
                     var button = document.createElement("button");
                     button.innerHTML = "Choose file";
                     button.setAttribute("data-display", fileboxname + "_path");
-                    button.setAttribute("data-filter", input.getAttribute("data-filter"));
+                    button.setAttribute("data-filter", input.getAttribute("data-filter") || "[]");
                     button.setAttribute("data-filemode", input.getAttribute("data-filemode"));
                     button.onclick = file_dialog;
 

--- a/htmlPy/binder.js
+++ b/htmlPy/binder.js
@@ -84,6 +84,7 @@ var bind_all = function () {
                     button.innerHTML = "Choose file";
                     button.setAttribute("data-display", fileboxname + "_path");
                     button.setAttribute("data-filter", input.getAttribute("data-filter"));
+                    button.setAttribute("data-filemode", input.getAttribute("data-filemode"));
                     button.onclick = file_dialog;
 
                     input.parentNode.insertBefore(disabledInput, input.nextSibling);

--- a/htmlPy/binder.js
+++ b/htmlPy/binder.js
@@ -41,11 +41,15 @@ var file_dialog = function (e) {
     e.preventDefault();
     var id_of_pseudo_filebox = e.target.getAttribute("data-display");
     var ext_filter_json = e.target.getAttribute("data-filter");
+    var filemode = e.target.getAttribute("data-filemode");
 
     if (ext_filter_json === null || ext_filter_json === "null")
         ext_filter_json = '[{"title": "Any file", "extensions": "*.*"}]';
 
-    var dialog = GUIHelper.file_dialog(ext_filter_json);
+    if (filemode === null || filemode === "null")
+        filemode = 'file';
+
+    var dialog = GUIHelper.file_dialog(filemode, ext_filter_json);
     document.getElementById(id_of_pseudo_filebox).value = dialog;
 
     return false;
@@ -66,7 +70,7 @@ var bind_all = function () {
         if(!forms[fi].classList.contains("htmlpy-activated")){
             forms[fi].onsubmit = form_bind;
             form = forms[fi];
-            for (i = 0, ii = form.length; i < ii; ++i) {
+            for (var i = form.length - 1; i >= 0; i--) {
                 var input = form[i];
                 if (input.type === "file") {
                     var fileboxname = input.getAttribute("name");
@@ -79,14 +83,14 @@ var bind_all = function () {
                     var button = document.createElement("button");
                     button.innerHTML = "Choose file";
                     button.setAttribute("data-display", fileboxname + "_path");
-                    button.setAttribute("data-filter", input.getAttribute("data-filter"));
+                    button.setAttribute("data-filter", input.getAttribute("data-filter") || "[]");
+                    button.setAttribute("data-filemode", input.getAttribute("data-filemode"));
                     button.onclick = file_dialog;
 
                     input.parentNode.insertBefore(disabledInput, input.nextSibling);
                     input.parentNode.insertBefore(button, disabledInput.nextSibling);
 
                     input.style.display = "none";
-                    form[i].remove();
                 }
             }
             forms[fi].classList.add("htmlpy-activated");

--- a/htmlPy/binder.js
+++ b/htmlPy/binder.js
@@ -41,11 +41,15 @@ var file_dialog = function (e) {
     e.preventDefault();
     var id_of_pseudo_filebox = e.target.getAttribute("data-display");
     var ext_filter_json = e.target.getAttribute("data-filter");
+    var filemode = e.target.getAttribute("data-filemode");
 
     if (ext_filter_json === null || ext_filter_json === "null")
         ext_filter_json = '[{"title": "Any file", "extensions": "*.*"}]';
 
-    var dialog = GUIHelper.file_dialog(ext_filter_json);
+    if (filemode === null || filemode === "null")
+        filemode = 'file';
+
+    var dialog = GUIHelper.file_dialog(filemode, ext_filter_json);
     document.getElementById(id_of_pseudo_filebox).value = dialog;
 
     return false;

--- a/htmlPy/gui_helper.py
+++ b/htmlPy/gui_helper.py
@@ -22,8 +22,8 @@ class GUIHelper(htmlPy.Object):
         """
         print(string)
 
-    @htmlPy.Slot(str, result=str)
-    def file_dialog(self, filters="[]"):
+    @htmlPy.Slot(str, str, result=str)
+    def file_dialog(self, filemode="file", filters="[]"):
         """ Opens a file selection dialog with given extension filter.
 
         HTML file inputs cannot be directly used with :py:class:`htmlPy.AppGUI`
@@ -32,16 +32,32 @@ class GUIHelper(htmlPy.Object):
         is automated with HTML file input.
 
         Keyword arguments:
+            filemode(str): A string of which style dialog to use. "file" and
+                "directory" are currently supported.
             filters (str): A JSON array of javascript objects of type {"title":
                 str (Title of the file extension), "extensions": str (space
                 separated list of extension wildcards)}. Example ``[{"title":
                 "JPEG files", "extensions": "*.jpg *.jpeg"}, {"title":
                 "PNG files", "extensions": "*.png"}]``
+                Applies only to filemode="file"
 
         """
         extensions = json.loads(filters)
         extensions_filter = ";;".join(map(lambda e: "{} ({})".format(
             e["title"], e["extensions"]), extensions))
         window = QtGui.QMainWindow()
-        return QtGui.QFileDialog.getOpenFileName(window, "Select file", ".",
-                                                 extensions_filter)[0]
+
+        dialog = QtGui.QFileDialog(window)
+
+        if filemode == "directory":
+            dialog.setFileMode(QtGui.QFileDialog.Directory)
+        else:
+            dialog.setFileMode(QtGui.QFileDialog.ExistingFile)
+            dialog.setFilter(extensions_filter)
+
+        if dialog.exec_():
+            filenames = dialog.selectedFiles()
+            return filenames[0]
+        else:
+            return ""
+


### PR DESCRIPTION
The commit messages sum it up, but there are a few fixes here.

The loop iterating over form elements to find inputs wouldn't catch my 2nd input, but running the interator while counting down and not removing the element works.

The main change is the ability to pass a 'data-filemode' attribute to text inputs:
```
<input type="file" name="open_directory" id="open_directory" data-filemode="directory"/>
```

If 'data-filemode' is given and is "directory", the button will open a Choose Directory dialog. If 'data-filemode' is not given or isn't "directory" it will default to "file" and work as usual.

I also added a 'data-for' attribute to the generated buttons for inputs. This way additional css and javascript can select and modify those buttons by referring to their 'data-for' attribute. The value is the 'name' attribute of the input the button was generated for. Using the example above, the button will have the attribute 'data-for="open_directory"'.

This has been tested with python 2.7.12 on Windows 10, but I would expect these changes to be compatible with all platforms.


Also, I found in your docs that you use this as the data-filters parameter:
```
"[{'title': 'title for extension', 'extensions': 'space separated extensions'}, {'title': 'title for another extension', 'extensions': 'space separated extensions'}]"
```
However, since the data must be valid JSON if only works if given as
```
data-filter='[{"title": "title for extension", "extensions": "space separated extensions"}, {"title": "title for another extension", "extensions": "space separated extensions"}]'
```
